### PR TITLE
Testing Correct API/HTTP Error Handling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,12 +250,26 @@ Users can choose to output the weather report to the terminal, CSV or JSON!
 
 ## Testing
 
-### 1. Pytest
+### 1. Unit Testing
 
+For testing of correct function output for the `dt_conversion.py` module using Pytest.
 From the activated virtual environment, run the following command:
 
 ```bash
-PYTHONPATH=src pytest
+PYTHONPATH=src pytest tests/test_dt_conversion.py
 ```
 
+If greater detail required from test results, add `--tb=long -vv` after pytest.
+
 Depreciation warning for `datetime.datetime.utcfromtimestamp()` is already known and accounted for.
+
+### 2. Integration Testing
+
+For testing of correct API/HTTP error handling of `weather_service.py`, without calling external API, using the requests-mock library and Pytest.
+From the activated virtual environment, run the following command:
+
+```bash
+PYTHONPATH=src pytest tests/test_weather_service.py
+```
+
+If greater detail required from test results, add `--tb=long -vv` after pytest.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pytest==8.4.1
 python-dotenv==1.0.0
 pytz==2023.3
 requests==2.31.0
+requests-mock==1.12.1
 timezonefinder==6.5.9
 tomli==2.2.1
 urllib3==2.4.0

--- a/src/weather_service.py
+++ b/src/weather_service.py
@@ -30,6 +30,15 @@ class WeatherService:
             # Returns a HTTP error if the request was unsuccessful, returns nothing otherwise
             response.raise_for_status()
         # Prints relevant error message and returns empty dictionary if the request was unsuccessful
+            data = response.json() # Assign response data to a variable
+            # Return dictionary from json variable
+            return {
+                "city": data["name"],  # City name
+                "temperature": data["main"]["temp"],  # Temperature in Celsius
+                "humidity": data["main"]["humidity"],  # Humidity percentage
+                "condition": data["weather"][0]["description"],  # Weather description
+                "local_time": convert_time(data["dt"], data["coord"])  # Local time of last update
+            }
         except requests.ConnectionError:
             print("Error: Unable to connect to the OpenWeatherMap API")
             return {}
@@ -45,15 +54,3 @@ class WeatherService:
         except KeyError as e:
             print(f"Data Error: Missing expected field {e}")
             return {}
-
-        if response:  # Check if response is not None before accessing it
-            data = response.json() # Assign response data to a variable
-            # Return dictionary from json variable
-            return {
-                "city": data["name"],  # City name
-                "temperature": data["main"]["temp"],  # Temperature in Celsius
-                "humidity": data["main"]["humidity"],  # Humidity percentage
-                "condition": data["weather"][0]["description"],  # Weather description
-                "local_time": convert_time(data["dt"], data["coord"])  # Local time of last update
-            }
-        return {}  # Return an empty dictionary if response is None

--- a/tests/test_weather_service.py
+++ b/tests/test_weather_service.py
@@ -71,6 +71,7 @@ def test_get_weather_data_timeout(requests_mock, capsys):
     assert result == {}, "On timeout, should return empty dict"
     assert "Error: Request timed out (10 seconds)" in captured.out
 
+
 def test_get_weather_data_connection_error(requests_mock, capsys):
     """Test handling of a timeout when retrieving weather data from the API."""
 
@@ -89,3 +90,18 @@ def test_get_weather_data_connection_error(requests_mock, capsys):
     # --- Assert ---
     assert result == {}, "On timeout, should return empty dict"
     assert "Error: Unable to connect to the OpenWeatherMap API" in captured.out
+
+
+def test_get_weather_data_http_error(requests_mock, capsys):
+    """Test handling of HTTP error when retrieving weather data from the API."""
+
+    requests_mock.get(
+        "https://api.openweathermap.org/data/2.5/weather",
+        status_code=404,
+        reason="Not Found"
+    )
+    ws = WeatherService(api_key="DUMMY_KEY")
+    result = ws.get_weather_data("TestCity")
+    captured = capsys.readouterr()
+    assert result == {}
+    assert "HTTP Error: 404 - Not Found" in captured.out

--- a/tests/test_weather_service.py
+++ b/tests/test_weather_service.py
@@ -105,3 +105,18 @@ def test_get_weather_data_http_error(requests_mock, capsys):
     captured = capsys.readouterr()
     assert result == {}
     assert "HTTP Error: 404 - Not Found" in captured.out
+
+
+def test_get_weather_data_generic_exception(monkeypatch, capsys):
+    """Test handling of an unexpected request exception when retrieving weather data."""
+
+    # Patch requests.get to raise a raw RequestException (not HTTPError, Timeout, etc.)
+    def raise_req_exception(*args, **kwargs):
+        raise requests.RequestException("test error")
+    monkeypatch.setattr(requests, "get", raise_req_exception)
+
+    ws = WeatherService(api_key="KEY")
+    result = ws.get_weather_data("City")
+    captured = capsys.readouterr()
+    assert result == {}
+    assert "Network Error: test error" in captured.out

--- a/tests/test_weather_service.py
+++ b/tests/test_weather_service.py
@@ -120,3 +120,28 @@ def test_get_weather_data_generic_exception(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert result == {}
     assert "Network Error: test error" in captured.out
+
+
+def test_get_weather_data_key_error(requests_mock, capsys, monkeypatch):
+    """Test handling of KeyError when retrieving weather data from the API."""
+
+    # Return JSON with missing expected fields
+    broken_json = {
+        "name": "City",
+        "main": {},  # missing 'temp'
+        "weather": [],  # missing [0]['description']
+        "dt": 123456789,
+        "coord": {"lat": 0, "lon": 0}
+    }
+
+    requests_mock.get(
+        "https://api.openweathermap.org/data/2.5/weather",
+        json=broken_json,
+        status_code=200
+    )
+
+    ws = WeatherService(api_key="KEY")
+    result = ws.get_weather_data("City")
+    captured = capsys.readouterr()
+    assert result == {}
+    assert "Data Error: Missing expected field" in captured.out

--- a/tests/test_weather_service.py
+++ b/tests/test_weather_service.py
@@ -70,3 +70,22 @@ def test_get_weather_data_timeout(requests_mock, capsys):
     # --- Assert ---
     assert result == {}, "On timeout, should return empty dict"
     assert "Error: Request timed out (10 seconds)" in captured.out
+
+def test_get_weather_data_connection_error(requests_mock, capsys):
+    """Test handling of a timeout when retrieving weather data from the API."""
+
+    # Simulate a timeout when requests.get is called
+    requests_mock.get(
+        "https://api.openweathermap.org/data/2.5/weather",
+        exc=requests.exceptions.ConnectionError
+    )
+
+    ws = WeatherService(api_key="DUMMY_KEY")
+    result = ws.get_weather_data("TestCity")
+
+    # Capture printed output
+    captured = capsys.readouterr()
+
+    # --- Assert ---
+    assert result == {}, "On timeout, should return empty dict"
+    assert "Error: Unable to connect to the OpenWeatherMap API" in captured.out


### PR DESCRIPTION
# Addition of Integration Testing for WeatherService

## What:

- Added a new file `tests/test_weather_service.py` in the root `tests` folder  
- Installed  `requests-mock` and added to `requirements.txt`  
- Created tests for `src/weather_service.py` covering both success and error paths  
- Stubbed out `dt_conversion.convert_time` via `monkeypatch` to isolate datetime logic  
- Covered these scenarios in tests:
  - Successful API response with valid JSON  
  - Timeout (`requests.exceptions.Timeout`)  
  - Connection error (`requests.exceptions.ConnectionError`)  
  - HTTP error (404 Not Found)  
  - Generic `requests.RequestException`  
  - Data‐error (`KeyError`) when JSON is malformed  
- Updated the “Testing” section of the README with instructions for running the new tests

## Why:

Ensuring that `WeatherService.get_weather_data` handles the full spectrum of real‐world API behaviors—success, network failures, HTTP errors, and malformed data—is critical to reliability. These integration tests simulate external conditions and catch edge cases early, preventing runtime surprises and regression when the API or our code changes.

## How:

### `test_get_weather_data_success`  
- Mocks a 200 OK response returning a valid JSON payload (`coord`, `weather`, `main`, `dt`, `name`)  
- Monkeypatches `dt_conversion.convert_time` to return a fixed timestamp  
- Asserts returned fields `city`, `temperature`, `humidity`, `condition`, and `local_time` match expectations  

### `test_get_weather_data_timeout`  
- Uses `requests-mock` to raise a `Timeout` on `requests.get`  
- Asserts method returns `{}` and prints `"Error: Request timed out (10 seconds)"`  

### `test_get_weather_data_connection_error`  
- Uses `requests-mock` to raise a `ConnectionError` on `requests.get`  
- Asserts method returns `{}` and prints `"Error: Unable to connect to the OpenWeatherMap API"`  

### `test_get_weather_data_http_error`  
- Mocks a 404 response with reason `"Not Found"`  
- Asserts method returns `{}` and prints `"HTTP Error: 404 - Not Found"`  

### `test_get_weather_data_generic_exception`  
- Monkeypatches `requests.get` to raise `RequestException("test error")`  
- Asserts method returns `{}` and prints `"Network Error: test error"`  

### `test_get_weather_data_key_error`  
- Mocks a 200 response with malformed JSON missing `main.temp` and `weather[0].description`  
- Asserts method returns `{}` and prints `"Data Error: Missing expected field"`  

## Dependencies:
- `pytest==8.4.1`  
- `requests-mock==1.11.0`

For successful testing, from the activated virtual environment, run:

```bash
PYTHONPATH=src pytest tests/test_weather_service.py
```