### PR TITLE
CLI Integration Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,3 +273,15 @@ PYTHONPATH=src pytest tests/test_weather_service.py
 ```
 
 If greater detail required from test results, add `--tb=long -vv` after pytest.
+
+### 3. CLI Integration Testing
+
+For testing user interaction with the CLI, ensuring that the app responds as expexted to various inputs, and that it outputs as expected given certain inputs.
+
+From the activated virtual environment, run the following command:
+
+```bash
+PYTHONPATH=src pytest tests/test_main_cli.py
+```
+
+If greater detail required from test results, add `--tb=long -vv` after pytest.

--- a/README.md
+++ b/README.md
@@ -250,12 +250,26 @@ Users can choose to output the weather report to the terminal, CSV or JSON!
 
 ## Testing
 
-### 1. Pytest
+### 1. Unit Testing
 
+For testing of correct function output for the `dt_conversion.py` module using Pytest.
 From the activated virtual environment, run the following command:
 
 ```bash
-PYTHONPATH=src pytest
+PYTHONPATH=src pytest tests/test_dt_conversion.py
 ```
 
+If greater detail required from test results, add `--tb=long -vv` after pytest.
+
 Depreciation warning for `datetime.datetime.utcfromtimestamp()` is already known and accounted for.
+
+### 2. Integration Testing
+
+For testing of correct API/HTTP error handling of `weather_service.py`, without calling external API, using the requests-mock library and Pytest.
+From the activated virtual environment, run the following command:
+
+```bash
+PYTHONPATH=src pytest tests/test_weather_service.py
+```
+
+If greater detail required from test results, add `--tb=long -vv` after pytest.

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1,0 +1,24 @@
+"""Test the main() function in main.py, which is the CLI entry point."""
+
+import builtins
+import pytest
+import main
+from weather_service import WeatherService
+
+class DummyHandler:
+    """A simple dummy output handler to simulate terminal output."""
+    
+    def output(self, data):
+        """Simulate outputting data to the terminal."""
+        print(f"OUTPUT: {data}")
+
+
+class InputDriver:
+    """A class to simulate user input for testing purposes."""
+
+    def __init__(self, responses):
+        self._iter = iter(responses)
+
+    def __call__(self, prompt=""):
+        return next(self._iter)
+

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -22,3 +22,34 @@ class InputDriver:
     def __call__(self, prompt=""):
         return next(self._iter)
 
+def test_cli_happy_path(monkeypatch, capsys):
+    """Test the main() function in main.py with a happy path scenario."""
+
+    monkeypatch.setenv("OWM_API_KEY", "DUMMY")
+
+    # Stub out the network call so we always get a valid dict
+    monkeypatch.setattr(
+        WeatherService, "get_weather_data",
+        lambda self, city: {
+            "city": city,
+            "temperature": 20,
+            "humidity": 50,
+            "condition": "sunny",
+            "local_time": "01-Jan-21 12:00 AM UTC"
+        }
+    )
+
+    # Patch the class imported in main.py
+    monkeypatch.setattr(main, "TerminalOutput", DummyHandler)
+
+    # Simulate typing: [menu choice, city name, exit]
+    responses = ["1", "TestCity", "exit"]
+    monkeypatch.setattr(builtins, "input", InputDriver(responses))
+
+    # Run main(); it'll call exit() on "exit", so catch the SystemExit
+    with pytest.raises(SystemExit):
+        main.main()
+
+    # Grab what was printed and verify our DummyHandler ran
+    out = capsys.readouterr().out
+    assert "OUTPUT: {'city': 'testcity', 'temperature': 20, 'humidity': 50" in out


### PR DESCRIPTION
# Addition of CLI Integration Testing for main.py

## What:

- Added `tests/test_main_cli.py` to the `tests` folder  
- Created tests for `main.py`’s `main()` CLI entry point  
- Introduced helper classes in tests:
  - `DummyHandler` to simulate `TerminalOutput` behavior  
  - `InputDriver` to feed a sequence of `input()` responses  
- Covered these scenarios:
  - Happy‐path: user selects “Get Weather,” enters a city, sees formatted output  
  - No‐data error: `WeatherService.get_weather_data()` returns empty dictionary, triggers error message  
- Updated “Testing” section in README with CLI test instructions

## Why:

Our CLI is the face of the app - if user prompts or output handling break, people will not use the app. These tests simulate full user interaction (menu choice, city name, exit) and ensure:

- The menu loop handles “exit” gracefully via `SystemExit`  
- Output handlers print exactly what we expect  
- Missing data branches surface the correct error message  

Catching these regressions early prevents bug reports.

## How:

### `test_cli_happy_path`
- Sets `OWM_API_KEY` in the environment  
- Monkeypatches `WeatherService.get_weather_data()` to return a fixed dictionary  
- Patches `main.TerminalOutput` to use `DummyHandler`  
- Feeds inputs `["1", "TestCity", "exit"]` via `InputDriver`  
- Expects a `SystemExit` and asserts that `"OUTPUT: {'city': 'testcity', ...}` appears in stdout  

### `test_cli_no_data_error`
- Sets `OWM_API_KEY` so `main()` doesn’t early‐exit  
- Monkeypatches `WeatherService.get_weather_data()` to return empty dictionary  
- Patches `main.TerminalOutput` to `DummyHandler`  
- Simulates inputs `["1", "BadCity", "exit"]`  
- Expects `SystemExit` and asserts that `"Value Error: No data found for the specified city."` is printed  

## Dependencies:
- `pytest==8.4.1`

**Run the CLI tests** from your activated virtual environment with:

```bash
PYTHONPATH=src pytest tests/test_main_cli.py